### PR TITLE
Arbitrary length ints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "native_codec_impl"
 crate-type = ["cdylib"]
 
 [dependencies.cpython]
-version = "0.2"
+version = "0.2.1"
 features = ["extension-module"]
 
 [dependencies]

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -206,7 +206,6 @@ impl<'a> Encoder<'a> {
     }
   }
 
-  #[inline]
   fn write_arbitrary_int(&mut self, val: &PyObject, size: u32) -> CodecResult<()> {
     if size < 256 {
       self.data.push(consts::TAG_SMALL_BIG_EXT);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -52,8 +52,7 @@ impl<'a> Encoder<'a> {
     let type_name_ref: &str = type_name.as_ref();
     match type_name_ref {
       "int" => {
-        let val: i64 = FromPyObject::extract(self.py, term)?;
-        return self.write_int(val)
+        return self.write_int(&term)
       },
       "float" => {
         let val: f64 = FromPyObject::extract(self.py, term)?;
@@ -196,7 +195,47 @@ impl<'a> Encoder<'a> {
 
 
   #[inline]
-  fn write_int(&mut self, val: i64) -> CodecResult<()> {
+  fn write_int(&mut self, val: &PyObject) -> CodecResult<()> {
+    let size: u64 = val.call_method(self.py, "bit_length", NoArgs, None)?.extract(self.py)?;
+    let size: u32 = (size / 8 + 1) as u32;
+    if size <= 4 {
+      let v: i64 = FromPyObject::extract(self.py, val)?;
+      self.write_4byte_int(v)
+    } else {
+      self.write_arbitrary_int(val, size)
+    }
+  }
+
+  #[inline]
+  fn write_arbitrary_int(&mut self, val: &PyObject, size: u32) -> CodecResult<()> {
+    if size < 256 {
+      self.data.push(consts::TAG_SMALL_BIG_EXT);
+      self.data.push(size as u8);
+    } else {
+      self.data.push(consts::TAG_LARGE_BIG_EXT);
+      self.data.write_u32::<BigEndian>(size);
+    }
+
+    let ltz: bool = val.call_method(self.py, "__lt__", (0, ), None)?.extract(self.py)?;
+    if ltz {
+      self.data.push(1 as u8); // we have a negative value
+      // we make new object that we multiply with -1 to switch sign, so that we get a positive
+      // value to pack
+      let r: PyObject = val.call_method(self.py, "__mul__", (-1, ), None)?.extract(self.py)?;
+      let b: PyBytes = r.call_method(self.py, "to_bytes", (size, "little"), None)?.extract(self.py)?;
+      let data: &[u8] = b.data(self.py);
+      self.data.write(data);
+    } else {
+      self.data.push( 0 as u8);
+      let b: PyBytes = val.call_method(self.py, "to_bytes", (size, "little"), None)?.extract(self.py)?;
+      let data: &[u8] = b.data(self.py);
+      self.data.write(data);
+    }
+    Ok(())
+  }
+
+  #[inline]
+  fn write_4byte_int(&mut self, val: i64) -> CodecResult<()> {
     if val >= 0 && val <= u8::MAX as i64 {
       self.data.push(consts::TAG_SMALL_UINT);
       self.data.push(val as u8);
@@ -270,7 +309,7 @@ impl<'a> Encoder<'a> {
       let chars_count = text.chars().count();
       self.data.write_u32::<BigEndian>(chars_count as u32); // chars, not bytes!
       for (_i, ch) in text.char_indices() {
-        self.write_int(ch as i64)?
+        self.write_4byte_int(ch as i64)?
       }
       self.data.push(consts::TAG_NIL_EXT) // list terminator
     }

--- a/test/etf_decode_test.py
+++ b/test/etf_decode_test.py
@@ -247,6 +247,78 @@ class TestETFDecode(unittest.TestCase):
 
     # ----------------
 
+    def test_decode_int_py(self):
+        self._decode_int(py_impl)
+
+    def test_decode_int_native(self):
+        self._decode_int(native_impl)
+
+    def _decode_int(self, codec):
+        positive = bytes([131, 98, 0, 0, 18, 139])  # 4747
+        negative = bytes([131, 98, 255, 255, 237, 117])  # -4747
+        (positive_val, positive_tail) = codec.binary_to_term(positive, None)
+        (negative_val, negative_tail) = codec.binary_to_term(negative, None)
+        self.assertEqual(positive_val, 4747)
+        self.assertEqual(positive_tail, b'')
+        self.assertEqual(negative_val, -4747)
+        self.assertEqual(negative_tail, b'')
+
+    # ----------------
+
+    def test_decode_small_big_py(self):
+        self._decode_small_big(py_impl)
+
+    def test_decode_small_big_native(self):
+        self._decode_small_big(native_impl)
+
+    def _decode_small_big(self, codec):
+        positive = bytes([131, 110, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])  # 2 ** 64
+        negative = bytes([131, 110, 9, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1])  # - (2 ** 64)
+        (positive_val, positive_tail) = codec.binary_to_term(positive, None)
+        (negative_val, negative_tail) = codec.binary_to_term(negative, None)
+        self.assertEqual(positive_val, 2 ** 64)
+        self.assertEqual(positive_tail, b'')
+        self.assertEqual(negative_val, -(2 ** 64))
+        self.assertEqual(negative_tail, b'')
+
+    # ----------------
+
+    def test_decode_large_big_py(self):
+        self._decode_large_big(py_impl)
+
+    def test_decode_large_big_native(self):
+        self._decode_large_big(native_impl)
+
+    def _decode_large_big(self, codec):
+        positive = bytes([131, 111, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])  # 2 ** 2040
+        negative = bytes([131, 111, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])  # - (2 ** 2040)
+        (positive_val, positive_tail) = codec.binary_to_term(positive, None)
+        (negative_val, negative_tail) = codec.binary_to_term(negative, None)
+        self.assertEqual(positive_val, 2 ** 2040)
+        self.assertEqual(positive_tail, b'')
+        self.assertEqual(negative_val, -(2 ** 2040))
+        self.assertEqual(negative_tail, b'')
+
+    # ----------------
+
     def test_decode_binary_py(self):
         self._decode_binary(py_impl)
 

--- a/test/etf_decode_test.py
+++ b/test/etf_decode_test.py
@@ -283,6 +283,28 @@ class TestETFDecode(unittest.TestCase):
 
     # ----------------
 
+    def test_decode_small_big_random_bytes_py(self):
+        self._decode_small_big_random_bytes(py_impl)
+
+    def test_decode_small_big_random_bytes_native(self):
+        self._decode_small_big_random_bytes(native_impl)
+
+    def _decode_small_big_random_bytes(self, codec):
+        positive = bytes([py_impl.ETF_VERSION_TAG, py_impl.TAG_SMALL_BIG_EXT, 13, 0,
+                          210, 10, 63, 78, 238, 224, 115, 195, 246, 15, 233, 142, 1
+                          ])
+        negative = bytes([py_impl.ETF_VERSION_TAG, py_impl.TAG_SMALL_BIG_EXT, 13, 1,
+                          210, 10, 63, 78, 238, 224, 115, 195, 246, 15, 233, 142, 1
+                          ])
+        (positive_val, positive_tail) = codec.binary_to_term(positive, None)
+        (negative_val, negative_tail) = codec.binary_to_term(negative, None)
+        self.assertEqual(positive_val, 123456789012345678901234567890)
+        self.assertEqual(positive_tail, b'')
+        self.assertEqual(negative_val, -123456789012345678901234567890)
+        self.assertEqual(negative_tail, b'')
+
+    # ----------------
+
     def test_decode_large_big_py(self):
         self._decode_large_big(py_impl)
 

--- a/test/etf_encode_test.py
+++ b/test/etf_encode_test.py
@@ -220,6 +220,73 @@ class TestETFEncode(unittest.TestCase):
 
     # ----------------
 
+    def test_encode_int_py(self):
+        self._encode_int(py_impl)
+
+    def test_encode_int_native(self):
+        self._encode_int(native_impl)
+
+    def _encode_int(self, codec):
+        positive = bytes([131, 98, 0, 0, 18, 139])  # 4747
+        negative = bytes([131, 98, 255, 255, 237, 117])  # -4747
+        b1 = codec.term_to_binary(4747, None)
+        b2 = codec.term_to_binary(-4747, None)
+        self.assertEqual(b1, positive)
+        self.assertEqual(b2, negative)
+
+    # ----------------
+
+    def test_encode_small_big_py(self):
+        self._encode_small_big(py_impl)
+
+    def test_encode_small_big_native(self):
+        self._encode_small_big(native_impl)
+
+    def _encode_small_big(self, codec):
+        # Bigger then 4 bytes lt 256
+        positive = bytes([131, 110, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])  # 2 ** 64
+        negative = bytes([131, 110, 9, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1])  # - (2 ** 64)
+        b1 = codec.term_to_binary(2 ** 64, None)
+        b2 = codec.term_to_binary(-(2 ** 64), None)
+        self.assertEqual(b1, positive)
+        self.assertEqual(b2, negative)
+
+    # ----------------
+    def test_encode_large_big_py(self):
+        self._encode_large_big(py_impl)
+
+    def test_encode_large_big_native(self):
+        self._encode_large_big(native_impl)
+
+    def _encode_large_big(self, codec):
+        # 256 bytes of int or more
+        positive = bytes([131, 111, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])  # 2 ** 2040
+        negative = bytes([131, 111, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])  # - (2 ** 2040)
+        b1 = codec.term_to_binary(2 ** 2040, None)
+        b2 = codec.term_to_binary(-(2 ** 2040), None)
+        self.assertEqual(b1, positive)
+        self.assertEqual(b2, negative)
+
+    # ----------------
+
     def test_encode_binary_py(self):
         self._encode_binary(py_impl)
 

--- a/test/etf_encode_test.py
+++ b/test/etf_encode_test.py
@@ -252,6 +252,27 @@ class TestETFEncode(unittest.TestCase):
         self.assertEqual(b2, negative)
 
     # ----------------
+
+    def test_encode_small_big_random_bytes_py(self):
+        self._encode_small_big_random_bytes(py_impl)
+
+    def test_encode_small_big_random_bytes_native(self):
+        self._encode_small_big_random_bytes(native_impl)
+
+    def _encode_small_big_random_bytes(self, codec):
+        positive = bytes([py_impl.ETF_VERSION_TAG, py_impl.TAG_SMALL_BIG_EXT, 13, 0,
+                          210, 10, 63, 78, 238, 224, 115, 195, 246, 15, 233, 142, 1
+                          ])
+        negative = bytes([py_impl.ETF_VERSION_TAG, py_impl.TAG_SMALL_BIG_EXT, 13, 1,
+                          210, 10, 63, 78, 238, 224, 115, 195, 246, 15, 233, 142, 1
+                          ])
+        b1 = codec.term_to_binary(123456789012345678901234567890, None)
+        b2 = codec.term_to_binary(-123456789012345678901234567890, None)
+        self.assertEqual(b1, positive)
+        self.assertEqual(b2, negative)
+
+    # ----------------
+
     def test_encode_large_big_py(self):
         self._encode_large_big(py_impl)
 


### PR DESCRIPTION
The possibility to encode / decode arbitrary length ints. Even though rust don't have arbitrary length ints, Erlang and Python do. Therefore I've added the possibility to encode / decode with the tags SMALL_BIG_EXT and LARGE_BIG_EXT. in 

Rust implementation there is no extraction to rust native type, instead we encode / decode directly to bytes.

There were decode function in python implementation, but there were a small bug in it.

This is my first PR with Rust, so please do help with code review.