### PR TITLE
Fixed error in float unpacking in tuples for example

### DIFF
--- a/term/py_codec_impl.py
+++ b/term/py_codec_impl.py
@@ -354,7 +354,7 @@ def binary_to_term_2(data: bytes, options: dict = None) -> (any, bytes):
 
     if tag == TAG_NEW_FLOAT_EXT:
         (result_f,) = struct.unpack(">d", data[1:9])
-        return result_f, data[10:]
+        return result_f, data[9:]
 
     if tag == TAG_SMALL_BIG_EXT:
         nbytes = data[1]

--- a/test/etf_decode_test.py
+++ b/test/etf_decode_test.py
@@ -241,8 +241,26 @@ class TestETFDecode(unittest.TestCase):
         data = bytes([py_impl.ETF_VERSION_TAG,
                       py_impl.TAG_NEW_FLOAT_EXT,  # a 8-byte IEEE double
                       64, 9, 33, 251, 84, 68, 45, 17])
+        negative = bytes([131, 70, 192, 71, 188, 40, 245, 194, 143, 92])
         (val, tail) = codec.binary_to_term(data, None)
+        (nval, ntail) = codec.binary_to_term(negative, None)
         self.assertEqual(val, 3.14159265358979)
+        self.assertEqual(tail, b'')
+        self.assertEqual(nval, -47.47)
+        self.assertEqual(ntail, b'')
+
+    # ----------------
+    def test_float_in_packed_type_py(self):
+        self._float_in_packed_type(py_impl)
+
+    def test_float_in_packed_type_native(self):
+        self._float_in_packed_type(native_impl)
+
+    def _float_in_packed_type(self, codec):
+        example = bytes([131, 104, 3, 70, 64, 9, 30, 184, 81, 235, 133, 31, 97, 13, 70, 64, 1,
+                         194, 143, 92, 40, 245, 195])
+        val, tail = codec.binary_to_term(example, None)
+        self.assertEqual(val, (3.14, 13, 2.22))
         self.assertEqual(tail, b'')
 
     # ----------------

--- a/test/etf_decode_test.py
+++ b/test/etf_decode_test.py
@@ -241,7 +241,9 @@ class TestETFDecode(unittest.TestCase):
         data = bytes([py_impl.ETF_VERSION_TAG,
                       py_impl.TAG_NEW_FLOAT_EXT,  # a 8-byte IEEE double
                       64, 9, 33, 251, 84, 68, 45, 17])
-        negative = bytes([131, 70, 192, 71, 188, 40, 245, 194, 143, 92])
+        negative = bytes([py_impl.ETF_VERSION_TAG,
+                          py_impl.TAG_NEW_FLOAT_EXT,
+                          192, 71, 188, 40, 245, 194, 143, 92])
         (val, tail) = codec.binary_to_term(data, None)
         (nval, ntail) = codec.binary_to_term(negative, None)
         self.assertEqual(val, 3.14159265358979)
@@ -257,8 +259,10 @@ class TestETFDecode(unittest.TestCase):
         self._float_in_packed_type(native_impl)
 
     def _float_in_packed_type(self, codec):
-        example = bytes([131, 104, 3, 70, 64, 9, 30, 184, 81, 235, 133, 31, 97, 13, 70, 64, 1,
-                         194, 143, 92, 40, 245, 195])
+        example = bytes([py_impl.ETF_VERSION_TAG, py_impl.TAG_SMALL_TUPLE_EXT, 3,
+                         py_impl.TAG_NEW_FLOAT_EXT, 64, 9, 30, 184, 81, 235, 133, 31,
+                         py_impl.TAG_SMALL_INT, 13,
+                         py_impl.TAG_NEW_FLOAT_EXT, 64, 1, 194, 143, 92, 40, 245, 195])
         val, tail = codec.binary_to_term(example, None)
         self.assertEqual(val, (3.14, 13, 2.22))
         self.assertEqual(tail, b'')


### PR DESCRIPTION
Small fix, we return 1 byte to little in the tail of the float unpack in the python implementation