### PR TITLE
Codec module improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ mod encoder;
 mod errors;
 mod helpers;
 
-py_exception!(term_codec, PyCodecError);
+py_exception!(native_codec_impl, PyCodecError);
 
 
 /// Strips 131 byte header and unpacks if the data was compressed.
@@ -86,6 +86,7 @@ fn m_init(py: Python, m: &PyModule) -> PyResult<()> {
         py_fn!(py, term_to_binary(py_term: PyObject, opt: PyObject)))?;
   m.add(py, "term_to_binary_2",
         py_fn!(py, term_to_binary_2(py_term: PyObject, opt: PyObject)))?;
+  m.add(py, "PyCodecError", py.get_type::<PyCodecError>())?;
   Ok(())
 }
 py_module_initializer!(

--- a/term/codec.py
+++ b/term/codec.py
@@ -2,37 +2,54 @@
     and then if import fails, uses Python codec implementation which is slower
     but always works.
 """
-import importlib
 import logging
 
 LOG = logging.getLogger("term")
 
 
 try:
-    # import term.native_codec_impl as co_impl
-    co_impl = importlib.import_module("native_codec_impl", "term")
-
-    def decorate(x):
-        """ For Native extension i've no idea how to make default arg value """
-        def wrapper(val, opt=None):
-            x(val, opt)
-        return wrapper
-
+    import term.native_codec_impl as co_impl
 except ImportError:
     LOG.warning("Native term ETF codec library import failed, falling back to slower Python impl")
     import term.py_codec_impl as co_impl
 
-    def decorate(x):
-        return x
 
-binary_to_term = decorate(co_impl.binary_to_term)
-binary_to_term_2 = decorate(co_impl.binary_to_term_2)
+def binary_to_term(data: bytes, options=None):
+    """
+    Strip 131 header and unpack if the data was compressed.
 
-term_to_binary = decorate(co_impl.term_to_binary)
-term_to_binary_2 = decorate(co_impl.term_to_binary_2)
+    :param data: The incoming encoded data with the 131 byte
+    :param options: Options dict (pending design)
+                    * "atom": "str" | "bytes" | "Atom" (default "Atom").
+                      Returns atoms as strings, as bytes or as atom.Atom objects.
+                    * "byte_string": "str" | "bytes" (default "str").
+                      Returns 8-bit strings as Python str or bytes.
+    :raises PyCodecError: when the tag is not 131, when compressed
+                          data is incomplete or corrupted
+    :returns: Remaining unconsumed bytes
+    """
+    return co_impl.binary_to_term(data, options)
+
+
+def term_to_binary(term: object, options=None):
+    """
+    Prepend the 131 header byte to encoded data.
+
+    :param opt: None or dict of options: "encode_hook" is a callable which
+                will return representation for unknown object types. Returning
+                None will be encoded as such and becomes Atom('undefined').
+    :returns: Bytes, the term object encoded with erlang binary term format
+    """
+    return co_impl.term_to_binary(term, options)
 
 PyCodecError = co_impl.PyCodecError
 
-__all__ = ['term_to_binary', 'term_to_binary_2',
-           'binary_to_term', 'binary_to_term_2',
-           'PyCodecError']
+# aliases
+
+encode = pack = dumps = term_to_binary
+decode = unpack = loads = binary_to_term
+
+__all__ = ['term_to_binary', 'binary_to_term', 'PyCodecError',
+           'encode', 'decode',
+           'pack', 'unpack',
+           'dumps', 'loads']


### PR DESCRIPTION
* Export Exception from rust lib
* Added wrapper functions to get common docs
* Added some aliases for binary_to_term and term_to_binary

I think making more explicit wrapper functions with documentation makes it more easy to work with.