### PR TITLE
Add option to decode STRING_EXT as int list (new)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = '1.0'
+VERSION = '1.1'
 PKGNAME = "term"
 DESCR = 'Erlang term and External Term Format codec in Python and native Rust extension'
 AUTHOR = 'Erlang Solutions Ltd and S2HC Sweden AB',

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -423,6 +423,16 @@ impl <'a> Decoder<'a> {
         *offset += sz;
         PyBytes::new(self.py, &in_bytes[offset1..(offset1 + sz)]).into_object()
       },
+      ByteStringRepresentation::IntList => {
+        let mut lst = Vec::<PyObject>::with_capacity(sz);
+        for i in 0..sz {
+          let val = &in_bytes[*offset+i];
+          let py_val = val.to_py_object(self.py).into_object();
+          lst.push(py_val);
+        };
+        *offset += sz;
+        PyList::new(self.py, lst.as_ref()).into_object()
+      },
     };
 
     let remaining = &in_bytes[*offset..];
@@ -601,4 +611,3 @@ pub fn wrap_decode_result(
     Err(e) => Err(e),
   }
 }
-

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -55,7 +55,8 @@ pub enum AtomRepresentation {
 #[derive(Eq, PartialEq)]
 pub enum ByteStringRepresentation {
   Bytes,
-  Str
+  Str,
+  IntList
 }
 
 
@@ -76,13 +77,14 @@ pub fn get_atom_opt(py: Python, opts1: &PyDict) -> CodecResult<AtomRepresentatio
 }
 
 
-/// Option: "byte_string" => "bytes" | "str" (default: str)
+/// Option: "byte_string" => "bytes" | "str" | "int_list" (default: str)
 pub fn get_byte_str_opt(py: Python, opts1: &PyDict) -> CodecResult<ByteStringRepresentation>
 {
   let opt_s: String = get_str_opt(py, &opts1, "byte_string", "str")?;
   match opt_s.as_ref() {
     "bytes" => Ok(ByteStringRepresentation::Bytes),
     "str" => Ok(ByteStringRepresentation::Str),
+    "int_list" => Ok(ByteStringRepresentation::IntList),
     other => {
       let txt = format!(
         "'byte_string' option is '{}' while expected: bytes, str", other);

--- a/term/codec.py
+++ b/term/codec.py
@@ -22,8 +22,8 @@ def binary_to_term(data: bytes, options=None, decode_hook=None):
     :param options: None or Options dict (pending design)
                     * "atom": "str" | "bytes" | "Atom" (default "Atom").
                       Returns atoms as strings, as bytes or as atom.Atom objects.
-                    * "byte_string": "str" | "bytes" (default "str").
-                      Returns 8-bit strings as Python str or bytes.
+                    * "byte_string": "str" | "bytes" | "int_list" (default "str").
+                      Returns 8-bit strings as Python str, bytes or list of integers.
     :param decode_hook: 
                 Key/value pairs t: str,f : callable, s.t. f(v) is run before encoding
                 for values v of type t. This allows for overriding the built-in encoding.

--- a/term/py_codec_impl.py
+++ b/term/py_codec_impl.py
@@ -88,8 +88,8 @@ def binary_to_term(data: bytes, options: dict = None) -> (any, bytes):
         :param options:
                * "atom": "str" | "bytes" | "Atom" (default "Atom").
                  Returns atoms as strings, as bytes or as atom.Atom objects.
-               * "byte_string": "str" | "bytes" (default "str").
-                 Returns 8-bit strings as Python str or bytes.
+               * "byte_string": "str" | "bytes" | "int_list" (default "str").
+                 Returns 8-bit strings as Python str or bytes or list of integers.
                * "decode_hook" : callable. Python function called for each
                  decoded term.
         :raises PyCodecError: when the tag is not 131, when compressed
@@ -155,6 +155,10 @@ def _get_create_atom_fn(opt: str) -> Callable:
 
 def _get_create_str_fn(opt: str) -> Callable:
     """ A tool function to create either a str or bytes from a 8-bit string. """
+
+    def _create_int_list(name: bytes) -> list:
+        return list(name)
+
     def _create_str_bytes(name: bytes) -> bytes:
         return name
 
@@ -165,6 +169,8 @@ def _get_create_str_fn(opt: str) -> Callable:
         return _create_str_str
     elif opt == "bytes":
         return _create_str_bytes
+    elif opt == "int_list":
+        return _create_int_list
 
     raise PyCodecError("Option 'byte_string' is '%s'; expected 'str', 'bytes'")
 
@@ -187,8 +193,8 @@ def binary_to_term_2(data: bytes, options: dict = None) -> (any, bytes):
         :param options: dict(str, _);
                 * "atom": "str" | "bytes" | "Atom"; default "Atom".
                   Returns atoms as strings, as bytes or as atom.Atom class objects
-               * "byte_string": "str" | "bytes" (default "str").
-                 Returns 8-bit strings as Python str or bytes.
+               * "byte_string": "str" | "bytes" | "int_list" (default "str").
+                 Returns 8-bit strings as Python str or bytes or int list.
         :param data: Bytes containing encoded term without 131 header
         :rtype: Tuple[Value, Tail: bytes]
         :return: The function consumes as much data as

--- a/test/etf_decode_test.py
+++ b/test/etf_decode_test.py
@@ -78,10 +78,12 @@ class TestETFDecode(unittest.TestCase):
     def test_decode_str_py(self):
         self._decode_str_ascii(py_impl)
         self._decode_str_unicode(py_impl)
+        self._decode_str_int_list(py_impl)
 
     def test_decode_str_native(self):
         self._decode_str_ascii(native_impl)
         self._decode_str_unicode(native_impl)
+        self._decode_str_int_list(py_impl)
 
     def _decode_str_ascii(self, codec):
         """ A string with bytes, encoded as optimized byte array. """
@@ -98,6 +100,16 @@ class TestETFDecode(unittest.TestCase):
                         "Result must be bytes, got " + t2.__class__.__name__)
         self.assertEqual(t2, b"hello")
         self.assertEqual(tail2, b'')
+
+
+    def _decode_str_int_list(self, codec):
+        """ A string with bytes, encoded as optimized byte array. """
+        b1 = bytes([131, py_impl.TAG_STRING_EXT,
+                    0, 5,
+                    104, 101, 108, 108, 111])
+        (t1, tail1) = codec.binary_to_term(b1, {"byte_string": "int_list"})
+        self.assertEqual(t1, [104, 101, 108, 108, 111])
+        self.assertEqual(tail1, b'')
 
     def _decode_str_unicode(self, codec):
         """ A string with emoji, encoded as a list of unicode integers. """


### PR DESCRIPTION
I fucked up my original #10 when trying to rebase and fix the conflict.
This is the same PR, but with an additional test in etf_decode_test.py

sorry for the confusion