### PR TITLE
Atoms

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -101,6 +101,7 @@ impl<'a> Encoder<'a> {
         return Ok(())
       },
       "Atom" => return self.write_atom(&term),
+      "StrictAtom" => return self.write_atom(&term),
       "str" => {
         let as_str = PyString::extract(self.py, &term)?;
         return self.write_str(&as_str)

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -75,7 +75,7 @@ impl<'a> Encoder<'a> {
   pub fn encode_default(&mut self, term: &PyObject) -> CodecResult<()> {
     let type_name = term.get_type(self.py).name(self.py).into_owned();
     let type_name_ref: &str = type_name.as_ref();
-	
+
     match type_name_ref {
       "int" => {
         return self.write_int(&term)
@@ -286,8 +286,7 @@ impl<'a> Encoder<'a> {
   /// Encode a UTF-8 Atom
   #[inline]
   fn write_atom(&mut self, py_atom: &PyObject) -> CodecResult<()> {
-    let py_text0 = py_atom.getattr(self.py, "text_")?;
-    let py_text: PyString = PyString::extract(self.py, &py_text0)?;
+    let py_text: PyString = PyString::extract(self.py, &py_atom)?;
     let text = py_text.to_string(self.py)?;
     self.write_atom_from_cow(text)
   }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -47,6 +47,7 @@ pub fn maybe_dict(py: Python, dict_or_none: PyObject) -> PyDict {
 #[derive(Eq, PartialEq, Copy, Clone)]
 pub enum AtomRepresentation {
   TermAtom,
+  TermStrictAtom,
   Bytes,
   Str,
 }
@@ -60,7 +61,7 @@ pub enum ByteStringRepresentation {
 }
 
 
-/// Option: "atom" => "bytes" | "str" | "Atom" (as Atom class, default)
+/// Option: "atom" => "bytes" | "str" | "Atom" | "StrictAtom" (as Atom class, default)
 pub fn get_atom_opt(py: Python, opts1: &PyDict) -> CodecResult<AtomRepresentation>
 {
   let opt_s = get_str_opt(py, &opts1, "atom", "Atom")?;
@@ -68,9 +69,10 @@ pub fn get_atom_opt(py: Python, opts1: &PyDict) -> CodecResult<AtomRepresentatio
     "bytes" => Ok(AtomRepresentation::Bytes),
     "str" => Ok(AtomRepresentation::Str),
     "Atom" => Ok(AtomRepresentation::TermAtom),
+    "StrictAtom" => Ok(AtomRepresentation::TermStrictAtom),
     other => {
       let txt = format!(
-        "'atom' option is '{}' while expected: bytes, str, Atom", other);
+        "'atom' option is '{}' while expected: bytes, str, Atom, StrictAtom", other);
       Err(CodecError::BadOptions {txt})
     }
   }

--- a/term/atom.py
+++ b/term/atom.py
@@ -16,19 +16,30 @@ ATOM_MARKER = "pyrlang.Atom"
 
 
 class Atom(str):
+    """ Stores a string decoded from Erlang atom. Encodes back to atom.
+
+        Be ware this won't separate itself from a string in a dict for example:
+
+            {Atom('foo'): 1, 'foo': 2} == {'foo': 2}
+    """
     def __repr__(self):
         return'Atom({})'.format(super(Atom, self).__repr__())
-    
-    
+
+
 class StrictAtom(Atom):
-    """ Stores a string decoded from Erlang atom. Encodes back to atom.
-        Can serve as a Python dictionary key.
+    """
+    Stores a string decoded from Erlang atom. Encodes back to atom.
+
+    Can serve as a Python dictionary key besides str with same content:w
+
+        {StrictAtom('foo'): 1, 'foo': 2} == {StrictAtom('foo'): 1, 'foo': 2}
+
     """
     def __repr__(self) -> str:
         return "Strict{}".format(super(StrictAtom, self).__repr__())
 
     def __str__(self):
         return self.__repr__()
-    
+
     def __hash__(self):
         return hash((ATOM_MARKER, super(StrictAtom, self).__hash__()))

--- a/term/atom.py
+++ b/term/atom.py
@@ -15,28 +15,20 @@
 ATOM_MARKER = "pyrlang.Atom"
 
 
-class Atom:
+class Atom(str):
+    def __repr__(self):
+        return'Atom({})'.format(super(Atom, self).__repr__())
+    
+    
+class StrictAtom(Atom):
     """ Stores a string decoded from Erlang atom. Encodes back to atom.
         Can serve as a Python dictionary key.
     """
-
-    def __init__(self, text: str) -> None:
-        self.text_ = text
-        """ Atom's text representation, supports unicode """
-
     def __repr__(self) -> str:
-        return "atom'%s'" % self.text_
+        return "Strict{}".format(super(StrictAtom, self).__repr__())
 
     def __str__(self):
-        return self.text_
-
-    def equals(self, other) -> bool:
-        return isinstance(other, Atom) and self.text_ == other.text_
-
-    __eq__ = equals
-
-    def __ne__(self, other):
-        return not self.equals(other)
-
+        return self.__repr__()
+    
     def __hash__(self):
-        return hash((ATOM_MARKER, self.text_))
+        return hash((ATOM_MARKER, super(StrictAtom, self).__hash__()))

--- a/term/codec.py
+++ b/term/codec.py
@@ -22,6 +22,7 @@ def binary_to_term(data: bytes, options=None, decode_hook=None):
     :param options: None or Options dict (pending design)
                     * "atom": "str" | "bytes" | "Atom" (default "Atom").
                       Returns atoms as strings, as bytes or as atom.Atom objects.
+                    * "atom_call": callabe object that returns the atom representation
                     * "byte_string": "str" | "bytes" | "int_list" (default "str").
                       Returns 8-bit strings as Python str, bytes or list of integers.
     :param decode_hook: 

--- a/term/py_codec_impl.py
+++ b/term/py_codec_impl.py
@@ -111,7 +111,7 @@ def binary_to_term(data: bytes, options: dict = None) -> (any, bytes):
             raise PyCodecError("Compressed size mismatch with actual")
     else:
         decode_data = data[1:]
-    
+
     decode_hook = options.get('decode_hook', {})
     val, rem = binary_to_term_2(decode_data, options)
     type_name_ref = type(val).__name__
@@ -141,7 +141,7 @@ def _get_create_atom_fn(opt: str) -> Callable:
         return name.decode(encoding)
 
     def _create_atom_atom(name: bytes, encoding: str) -> Atom:
-        return Atom(text=name.decode(encoding))
+        return Atom(name.decode(encoding))
 
     if opt == "Atom":
         return _create_atom_atom
@@ -309,7 +309,7 @@ def binary_to_term_2(data: bytes, options: dict = None) -> (any, bytes):
         creation = tail[8]
 
         assert isinstance(node, Atom)
-        pid = Pid(node_name=node.text_,
+        pid = Pid(node_name=node,
                   id=id1,
                   serial=serial,
                   creation=creation)
@@ -324,7 +324,7 @@ def binary_to_term_2(data: bytes, options: dict = None) -> (any, bytes):
         id_len = 4 * term_len
         id1 = tail[1:id_len + 1]
 
-        ref = Reference(node_name=node.text_,
+        ref = Reference(node_name=node,
                         creation=creation,
                         refid=id1)
         return ref, tail[id_len + 1:]
@@ -634,7 +634,7 @@ def term_to_binary_2(val, encode_hook: [Callable, None]) -> bytes:
         return _pack_atom('undefined')
 
     elif isinstance(val, Atom):
-        return _pack_atom(val.text_)
+        return _pack_atom(val)
 
     elif isinstance(val, ImproperList):
         return _pack_list(val.elements_, val.tail_, encode_hook)
@@ -670,7 +670,7 @@ def term_to_binary_2(val, encode_hook: [Callable, None]) -> bytes:
 
 def term_to_binary(val, opt: Union[None, dict] = None) -> bytes:
     """ Prepend the 131 header byte to encoded data.
-        :param opt: 
+        :param opt:
             None or a dict with key value pairs (t,v) where t
             is a python type (as string, i.e. 'int' not int) and v a callable
             operating on an object of type t.

--- a/test/etf_decode_test.py
+++ b/test/etf_decode_test.py
@@ -27,7 +27,7 @@ class TestETFDecode(unittest.TestCase):
                     104, 101, 108, 108, 111])
         (t1, tail1) = codec.binary_to_term(b1, None)
         self.assertTrue(isinstance(t1, Atom), "Result must be Atom object")
-        self.assertEqual(t1.text_, "hello")
+        self.assertEqual(t1, "hello")
         self.assertEqual(tail1, b'')
 
         b2 = bytes([131, py_impl.TAG_SMALL_ATOM_EXT,
@@ -35,7 +35,7 @@ class TestETFDecode(unittest.TestCase):
                     104, 101, 108, 108, 111])
         (t2, tail2) = codec.binary_to_term(b2, None)
         self.assertTrue(isinstance(t2, Atom), "Result must be Atom object")
-        self.assertEqual(t2.text_, "hello")
+        self.assertEqual(t2, "hello")
         self.assertEqual(tail2, b'')
 
     def _decode_atom_utf8(self, codec):
@@ -44,8 +44,8 @@ class TestETFDecode(unittest.TestCase):
                     108, 195, 164, 103, 101, 116])
         (t1, tail1) = codec.binary_to_term(b1, None)
         self.assertTrue(isinstance(t1, Atom), "Result must be Atom object")
-        self.assertTrue(isinstance(t1.text_, str), "Result .text_ field must be str")
-        self.assertEqual(t1.text_, u"läget")
+        self.assertTrue(isinstance(t1, str), "Result must be str")
+        self.assertEqual(t1, u"läget")
         self.assertEqual(tail1, b'')
 
     # ----------------

--- a/test/etf_decode_test.py
+++ b/test/etf_decode_test.py
@@ -2,7 +2,7 @@ import unittest
 
 from term import py_codec_impl as py_impl
 import term.native_codec_impl as native_impl
-from term.atom import Atom
+from term.atom import Atom, StrictAtom
 from term.pid import Pid
 from term.reference import Reference
 from term.fun import Fun
@@ -72,6 +72,83 @@ class TestETFDecode(unittest.TestCase):
                         "Expected bytes, have: " + t3.__class__.__name__)
         self.assertEqual(t3, b'hello')
         self.assertEqual(tail3, b'')
+
+    # ----------------
+
+    def test_decode_atom_as_strict_py(self):
+        self._decode_atom_as_strict(py_impl)
+
+    def test_decode_atom_as_strict_native(self):
+        self._decode_atom_as_strict(native_impl)
+
+    def _decode_atom_as_strict(self, codec):
+        b1 = bytes([131, py_impl.TAG_ATOM_EXT,
+                    0, 5,
+                    104, 101, 108, 108, 111])
+        (t1, tail1) = codec.binary_to_term(b1, {"atom": "StrictAtom"})
+        self.assertTrue(isinstance(t1, StrictAtom), "Result must be StrictAtom "
+                                                    "got {}".format(type(t1)))
+        self.assertEqual(t1, "hello")
+        self.assertEqual(tail1, b'')
+
+        b2 = bytes([131, py_impl.TAG_SMALL_ATOM_EXT,
+                    5,
+                    104, 101, 108, 108, 111])
+        (t2, tail2) = codec.binary_to_term(b2, {"atom": "StrictAtom"})
+        self.assertTrue(isinstance(t2, StrictAtom), "Result must be Atom "
+                                                    "object")
+        self.assertEqual(t2, "hello")
+        self.assertEqual(tail2, b'')
+
+    # ----------------
+
+    def test_decode_atom_custom_callable_py(self):
+        self._decode_atom_custom_callable(py_impl)
+        self._decode_atom_custom_class(py_impl)
+
+    def test_decode_atom_custom_callable_native(self):
+        self._decode_atom_custom_callable(native_impl)
+        self._decode_atom_custom_class(native_impl)
+
+    def _decode_atom_custom_callable(self, codec):
+        b1 = bytes([131, py_impl.TAG_ATOM_EXT,
+                    0, 5,
+                    104, 101, 108, 108, 111])
+
+        a_fun = lambda x: bytes(x.encode('utf8'))
+        (t1, tail1) = codec.binary_to_term(b1, {"atom_call": a_fun})
+        self.assertTrue(isinstance(t1, bytes))
+        self.assertEqual(t1, b"hello")
+        self.assertEqual(tail1, b'')
+
+    def _decode_atom_custom_class(self, codec):
+
+        b1 = bytes([131, py_impl.TAG_ATOM_EXT,
+                    0, 5,
+                    104, 101, 108, 108, 111])
+
+        class A(str):
+            pass
+
+        class B:
+            def __init__(self, text):
+                self._text = text
+
+        (t1, tail1) = codec.binary_to_term(b1, {"atom_call": str})
+        self.assertTrue(isinstance(t1, str))
+        self.assertEqual(t1, "hello")
+        self.assertEqual(tail1, b'')
+
+        (t2, tail2) = codec.binary_to_term(b1, {"atom_call": A})
+        self.assertTrue(isinstance(t2, str))
+        self.assertTrue(isinstance(t2, A))
+        self.assertEqual(t1, "hello")
+        self.assertEqual(tail1, b'')
+
+        (t3, tail3) = codec.binary_to_term(b1, {"atom_call": B})
+        self.assertTrue(isinstance(t3, B))
+        self.assertEqual(t3._text, "hello")
+        self.assertEqual(tail1, b'')
 
     # ----------------
 

--- a/test/etf_encode_test.py
+++ b/test/etf_encode_test.py
@@ -4,7 +4,7 @@ from term import py_codec_impl as py_impl
 from term import native_codec_impl as native_impl
 from term import codec as default_impl
 
-from term.atom import Atom
+from term.atom import Atom, StrictAtom
 from term.pid import Pid
 from term.reference import Reference
 # from term.fun import Fun
@@ -14,14 +14,22 @@ from term.bitstring import BitString
 
 class TestETFEncode(unittest.TestCase):
     def test_encode_atom_py(self):
-        self._encode_atom(py_impl)
-        self._encode_atom_utf8(py_impl)
+        self._encode_atom(py_impl, Atom)
+        self._encode_atom_utf8(py_impl, Atom)
 
     def test_encode_atom_native(self):
-        self._encode_atom(native_impl)
-        self._encode_atom_utf8(native_impl)
+        self._encode_atom(native_impl, Atom)
+        self._encode_atom_utf8(native_impl, Atom)
 
-    def _encode_atom(self, codec):
+    def test_encode_strict_atom_py(self):
+        self._encode_atom(py_impl, Atom)
+        self._encode_atom_utf8(py_impl, Atom)
+
+    def test_encode_strict_atom_native(self):
+        self._encode_atom(native_impl, Atom)
+        self._encode_atom_utf8(native_impl, Atom)
+
+    def _encode_atom(self, codec, atom_cls):
         """ Try an atom 'hello' encoded as Latin1 atom (16-bit length)
             or small atom (8bit length)
         """
@@ -31,7 +39,7 @@ class TestETFEncode(unittest.TestCase):
         example1 = bytes([py_impl.ETF_VERSION_TAG,
                           py_impl.TAG_ATOM_UTF8_EXT, 1, 4]) \
                    + (b'hello' * repeat1)
-        b1 = codec.term_to_binary(Atom("hello" * repeat1), None)
+        b1 = codec.term_to_binary(atom_cls("hello" * repeat1), None)
         self.assertEqual(b1, example1)
 
         # Create and encode 'hello...hello' 5 times (25 bytes)
@@ -39,16 +47,16 @@ class TestETFEncode(unittest.TestCase):
         example2 = bytes([py_impl.ETF_VERSION_TAG,
                           py_impl.TAG_SMALL_ATOM_UTF8_EXT, 25]) \
                    + (b'hello' * repeat2)
-        b2 = codec.term_to_binary(Atom("hello" * repeat2), None)
+        b2 = codec.term_to_binary(atom_cls("hello" * repeat2), None)
         self.assertEqual(b2, example2)
 
-    def _encode_atom_utf8(self, codec):
+    def _encode_atom_utf8(self, codec, atom_cls):
         # Create and encode 'hallå...hallå' 50 times (300 bytes)
         repeat1 = 50
         example1 = bytes([py_impl.ETF_VERSION_TAG,
                           py_impl.TAG_ATOM_UTF8_EXT, 1, (300-256)]) \
                    + (bytes("hallå", "utf8") * repeat1)
-        b1 = codec.term_to_binary(Atom("hallå" * repeat1), None)
+        b1 = codec.term_to_binary(atom_cls("hallå" * repeat1), None)
         self.assertEqual(b1, example1)
 
         # Create and encode 'hallå...hallå' 5 times (30 bytes)
@@ -56,7 +64,7 @@ class TestETFEncode(unittest.TestCase):
         example2 = bytes([py_impl.ETF_VERSION_TAG,
                           py_impl.TAG_SMALL_ATOM_UTF8_EXT, 30]) \
                    + (bytes("hallå", "utf8") * repeat2)
-        b2 = codec.term_to_binary(Atom("hallå" * repeat2), None)
+        b2 = codec.term_to_binary(atom_cls("hallå" * repeat2), None)
         self.assertEqual(b2, example2)
 
     # ---------------------


### PR DESCRIPTION
Make the native Atom representations inherit from str. Made 2 types
* Atom: behaves like a str `Atom("foo") == "foo"`
* StrictAtom: inherits from str so still valid for keyword args etc, StrictAtom can be uniquely used in a dict with str `{StrictAtom("foo"): 1, "foo": 2}`

Added the option `atom_call` option, this is supose to be a callable object (fun or class) if you want to inject you own atom representation.

Added some test cases.