### PR TITLE
Codec support for NEW_PID and NEWER_REFERENCE

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -47,3 +47,6 @@ pub const TAG_SMALL_BIG_EXT: u8 = 110;
 pub const TAG_SMALL_UINT: u8 = 97;
 pub const TAG_SMALL_TUPLE_EXT: u8 = 104;
 pub const TAG_STRING_EXT: u8 = 107;
+
+pub const TAG_NEW_PID_EXT: u8 = 88;
+pub const TAG_NEWER_REF_EXT: u8 = 90;

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -607,7 +607,6 @@ impl <'a> Decoder<'a> {
     let (node, tail1) = self.decode(&in_bytes[*offset..])?;
     self.atom_representation = save_repr;
 
-    //let creation: u32 = tail1.read_with::<u32>(offset, byte::BE)?;
     let creation: u32 = BigEndian::read_u32(tail1);
     let last_index = 4 + (term_len as usize) * 4;
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -15,6 +15,7 @@
 use cpython::*;
 use byte::BytesExt;
 use byte::ctx::Str;
+use byteorder::{ByteOrder, BigEndian};
 use compress::zlib;
 use std::io::{Read, BufReader};
 use std::str;
@@ -161,7 +162,9 @@ impl <'a> Decoder<'a> {
         self.parse_tuple(&in_bytes[5..], arity as usize)
       },
       consts::TAG_PID_EXT => self.parse_pid(tail),
+      consts::TAG_NEW_PID_EXT => self.parse_new_pid(tail),
       consts::TAG_NEW_REF_EXT => self.parse_ref(tail),
+      consts::TAG_NEWER_REF_EXT => self.parse_newer_ref(tail),
       consts::TAG_NEW_FUN_EXT => self.parse_fun(tail),
       _ => Err(CodecError::UnknownTermTagByte { b: tag }),
     };
@@ -543,6 +546,28 @@ impl <'a> Decoder<'a> {
   }
 
 
+  /// Given input _after_ the NEW_PID tag byte, parse an external pid
+  #[inline]
+  fn parse_new_pid<'inp>(&mut self, in_bytes: &'inp [u8]) -> CodecResult<(PyObject, &'inp [u8])>
+  {
+    // Temporarily switch atom representation to binary and then decode node
+    let save_repr = self.atom_representation;
+    self.atom_representation = AtomRepresentation::Str;
+    let (node, tail1) = self.decode(in_bytes)?;
+    self.atom_representation = save_repr;
+
+    let offset = &mut 0usize;
+    let id: u32 = tail1.read_with::<u32>(offset, byte::BE)?;
+    let serial: u32 = tail1.read_with::<u32>(offset, byte::BE)?;
+    let creation: u32 = tail1.read_with::<u32>(offset, byte::BE)?;
+
+    let remaining = &tail1[*offset..];
+    let pid_obj = self.get_pid_pyclass();
+    let py_pid = pid_obj.call(self.py, (node, id, serial, creation), None)?;
+    Ok((py_pid.into_object(), remaining))
+  }
+
+
   /// Given input _after_ the Reference tag byte, parse an external reference
   #[inline]
   fn parse_ref<'inp>(&mut self, in_bytes: &'inp [u8]) -> CodecResult<(PyObject, &'inp [u8])>
@@ -560,6 +585,33 @@ impl <'a> Decoder<'a> {
     let last_index = 1 + (term_len as usize) * 4;
 
     let id: &[u8] = &tail1[1..last_index];
+    let bytes_id = PyBytes::new(self.py, id);
+
+    let remaining = &tail1[last_index..];
+    let ref_obj = self.get_ref_pyclass();
+    let py_ref = ref_obj.call(self.py, (node, creation, bytes_id), None)?;
+    Ok((py_ref.into_object(), remaining))
+  }
+
+
+  /// Given input _after_ the Newer Reference tag byte, parse an external reference
+  #[inline]
+  fn parse_newer_ref<'inp>(&mut self, in_bytes: &'inp [u8]) -> CodecResult<(PyObject, &'inp [u8])>
+  {
+    let offset = &mut 0usize;
+    let term_len: u16 = in_bytes.read_with::<u16>(offset, byte::BE)?;
+
+    // Temporarily switch atom representation to binary and then decode node
+    let save_repr = self.atom_representation;
+    self.atom_representation = AtomRepresentation::Str;
+    let (node, tail1) = self.decode(&in_bytes[*offset..])?;
+    self.atom_representation = save_repr;
+
+    //let creation: u32 = tail1.read_with::<u32>(offset, byte::BE)?;
+    let creation: u32 = BigEndian::read_u32(tail1);
+    let last_index = 4 + (term_len as usize) * 4;
+
+    let id: &[u8] = &tail1[4..last_index];
     let bytes_id = PyBytes::new(self.py, id);
 
     let remaining = &tail1[last_index..];

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -356,13 +356,13 @@ impl<'a> Encoder<'a> {
     let serial: u32 = FromPyObject::extract(self.py, &py_serial)?;
 
     let py_creation = py_pid.getattr(self.py, "creation_")?;
-    let creation: u8 = FromPyObject::extract(self.py, &py_creation)?;
+    let creation: u32 = FromPyObject::extract(self.py, &py_creation)?;
 
-    self.data.push(consts::TAG_PID_EXT);
+    self.data.push(consts::TAG_NEW_PID_EXT);
     self.write_atom_from_cow(node_name.to_string(self.py)?);
     self.data.write_u32::<BigEndian>(id);
     self.data.write_u32::<BigEndian>(serial);
-    self.data.push(creation);
+    self.data.write_u32::<BigEndian>(creation);
 
     Ok(())
   }
@@ -381,12 +381,12 @@ impl<'a> Encoder<'a> {
     let id = py_id.data(self.py);
 
     let py_creation = py_ref.getattr(self.py, "creation_")?;
-    let creation: u8 = FromPyObject::extract(self.py, &py_creation)?;
+    let creation: u32 = FromPyObject::extract(self.py, &py_creation)?;
 
-    self.data.push(consts::TAG_NEW_REF_EXT);
+    self.data.push(consts::TAG_NEWER_REF_EXT);
     self.data.write_u16::<BigEndian>((id.len() / 4) as u16);
     self.write_atom_from_cow(node_name.to_string(self.py)?);
-    self.data.push(creation);
+    self.data.write_u32::<BigEndian>(creation);
     self.data.write(id);
 
     Ok(())

--- a/test/etf_decode_test.py
+++ b/test/etf_decode_test.py
@@ -248,6 +248,22 @@ class TestETFDecode(unittest.TestCase):
 
     # ----------------
 
+    def test_decode_new_pid_py(self):
+        self._decode_new_pid(py_impl)
+
+    def test_decode_new_pid_native(self):
+        self._decode_new_pid(native_impl)
+
+    def _decode_new_pid(self, codec):
+        """ Try a new pid """
+        data = bytes([131, 88, 100, 0, 13, 101, 114, 108, 64, 49, 50, 55, 46,
+                      48, 46, 48, 46, 49, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 1])
+        (val, tail) = codec.binary_to_term(data, None)
+        self.assertTrue(isinstance(val, Pid))
+        self.assertEqual(tail, b'')
+
+    # ----------------
+
     def test_decode_ref_py(self):
         self._decode_ref(py_impl)
 
@@ -259,6 +275,23 @@ class TestETFDecode(unittest.TestCase):
         b1 = bytes([131, 114, 0, 3, 100, 0, 13, 101, 114, 108, 64, 49, 50,
                     55, 46, 48, 46, 48, 46, 49, 1, 0, 0, 1, 58, 0, 0, 0, 2,
                     0, 0, 0, 0])
+        (t1, tail) = codec.binary_to_term(b1, None)
+        self.assertTrue(isinstance(t1, Reference))
+        self.assertEqual(tail, b'')
+
+    # ----------------
+
+    def test_decode_newer_ref_py(self):
+        self._decode_newer_ref(py_impl)
+
+    def test_decode_newer_ref_native(self):
+        self._decode_newer_ref(native_impl)
+
+    def _decode_newer_ref(self, codec):
+        """ Try a newer reference """
+        b1 = bytes([131, 90, 0, 3, 100, 0, 13, 101, 114, 108, 64, 49, 50,
+                    55, 46, 48, 46, 48, 46, 49, 0, 0, 0, 1, 0, 0, 1, 58,
+                    0, 0, 0, 2, 0, 0, 0, 0])
         (t1, tail) = codec.binary_to_term(b1, None)
         self.assertTrue(isinstance(t1, Reference))
         self.assertEqual(tail, b'')

--- a/test/etf_encode_test.py
+++ b/test/etf_encode_test.py
@@ -181,12 +181,12 @@ class TestETFEncode(unittest.TestCase):
 
     def _encode_pid(self, codec):
         sample1 = bytes([py_impl.ETF_VERSION_TAG,
-                         py_impl.TAG_PID_EXT,
+                         py_impl.TAG_NEW_PID_EXT,
                          py_impl.TAG_SMALL_ATOM_UTF8_EXT, 13]) \
                   + bytes("nonode@nohost", "latin-1") \
                   + bytes([0, 0, 0, 1,
                            0, 0, 0, 2,
-                           3])
+                           0, 0, 0, 3])
         val = Pid("nonode@nohost", 1, 2, 3)
         bin1 = codec.term_to_binary(val, None)
         self.assertEqual(bin1, sample1)
@@ -202,11 +202,11 @@ class TestETFEncode(unittest.TestCase):
     def _encode_ref(self, codec):
         creation = 1
         sample1 = bytes([py_impl.ETF_VERSION_TAG,
-                         py_impl.TAG_NEW_REF_EXT,
+                         py_impl.TAG_NEWER_REF_EXT,
                          0, 3,  # length
                          py_impl.TAG_SMALL_ATOM_UTF8_EXT, 13,
                          110, 111, 110, 111, 100, 101, 64, 110, 111, 104, 111, 115, 116,
-                         creation]) \
+                         0, 0, 0, creation]) \
                   + bytes("fgsfdsfdsfgs", "latin-1")
 
         val = Reference("nonode@nohost", creation, b'fgsfdsfdsfgs')


### PR DESCRIPTION
These are mandatory for R23. The codec unconditionally emits these new encodings, just like R23 does. R19 and higher supports them.