### PR TITLE
Fix off-by-one in tail preservation in Python NEW_PID decoding

### DIFF
--- a/term/py_codec_impl.py
+++ b/term/py_codec_impl.py
@@ -346,7 +346,7 @@ def binary_to_term_2(data: bytes, options: dict = None) -> (any, bytes):
                   id=id1,
                   serial=serial,
                   creation=creation)
-        return pid, tail[13:]
+        return pid, tail[12:]
 
     if tag == TAG_NEW_REF_EXT:
         if len(data) < 2:


### PR DESCRIPTION
This also updates the decode test suite to catch errors like this.