### PR TITLE
py_codec: Consider signedness when encoding integers

### DIFF
--- a/term/py_codec_impl.py
+++ b/term/py_codec_impl.py
@@ -512,7 +512,7 @@ def _pack_int(val: int):
     if 0 <= val < 256:
         return bytes([TAG_SMALL_INT, val])
     size = val.bit_length()
-    if size <= 32:
+    if size < 32:
         return bytes([TAG_INT]) + util.to_i32(val)
     # we get here we're packing smal or large big
     sign = 0 if 0 <= val else 1


### PR DESCRIPTION
Pythons `bit_length` function represents the bit size excluding the sign bit. When
encoding a 32bit integer it must use less than 32bits to fit otherwise it will fail for numbers in range `2147483647..4294967295` and `-4294967295..-2147483647`

A quick review of the rust code indicates it is handled correct there.