### PR TITLE
Fix type hints for Python 3.8 (and earlier) support

### DIFF
--- a/term/codec.py
+++ b/term/codec.py
@@ -3,6 +3,7 @@
     but always works.
 """
 import logging
+from typing import Tuple
 
 from term.basetypes import BaseTerm, Term
 
@@ -15,7 +16,7 @@ except ImportError:
     import term.py_codec_impl as co_impl
 
 
-def binary_to_term(data: bytes, options=None, decode_hook=None) -> tuple[Term, bytes]:
+def binary_to_term(data: bytes, options=None, decode_hook=None) -> Tuple[Term, bytes]:
     """
     Strip 131 header and unpack if the data was compressed.
 

--- a/term/list.py
+++ b/term/list.py
@@ -52,7 +52,7 @@ def list_to_unicode_str(lst: list) -> str:
     return "".join(map(chr, lst))
 
 
-def list_to_str(lst: list[int]) -> str:
+def list_to_str(lst: List[int]) -> str:
     """ A helper function to convert a list of bytes (0..255) into an
         ASCII string. """
     return bytearray(lst).decode('utf-8')

--- a/term/py_codec_impl.py
+++ b/term/py_codec_impl.py
@@ -17,7 +17,7 @@
 """
 import math
 import struct
-from typing import Callable, Union, Optional, Any, Type
+from typing import Callable, Union, Optional, Any, Type, Dict, Tuple, Set
 
 from zlib import decompressobj
 
@@ -67,7 +67,7 @@ TAG_STRING_EXT = 107
 TAG_NEW_PID_EXT = 88
 TAG_NEWER_REF_EXT = 90
 
-EncodeHookType = Optional[dict[str, Callable[[Any], Any]]]
+EncodeHookType = Optional[Dict[str, Callable[[Any], Any]]]
 
 
 # This is Python variant of codec exception when Python impl is used.
@@ -87,7 +87,7 @@ def incomplete_data(where=""):
         raise PyCodecError("Incomplete data")
 
 
-def binary_to_term(data: bytes, options: Optional[dict] = None) -> tuple[Term, bytes]:
+def binary_to_term(data: bytes, options: Optional[dict] = None) -> Tuple[Term, bytes]:
     """ Strip 131 header and unpack if the data was compressed.
 
         :param data: The incoming encoded data with the 131 byte
@@ -193,7 +193,7 @@ def _get_create_str_fn(opt: str) -> Callable:
     raise PyCodecError("Option 'byte_string' is '%s'; expected 'str', 'bytes'")
 
 
-def binary_to_term_2(data: bytes, options: Optional[dict] = None) -> tuple[Term, bytes]:
+def binary_to_term_2(data: bytes, options: Optional[dict] = None) -> Tuple[Term, bytes]:
     """ Proceed decoding after leading tag has been checked and removed.
 
         Erlang lists are decoded into ``term.List`` object, whose ``elements_``
@@ -575,7 +575,7 @@ def _is_a_simple_object(obj):
         or isinstance(obj, Reference)
 
 
-def generic_serialize_object(obj, cycle_detect: Optional[set[int]] = None):
+def generic_serialize_object(obj, cycle_detect: Optional[Set[int]] = None):
     """ Given an arbitraty Python object creates a tuple (ClassName, {Fields}).
         A fair effort is made to avoid infinite recursion on cyclic objects.
         :param obj: Arbitrary object to encode


### PR DESCRIPTION
PEP 585 style parametrized generic types require Python 3.9 or later.